### PR TITLE
Idempotent server startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@ GO = go
 BINDIR := bin
 BINARY := remindme
 
-VERSION = v1.1.0
+VERSION = v1.1.1
 GIT_SHA = $(shell git rev-parse HEAD)
 LDFLAGS = -ldflags '-w -s -extldflags "-static" -X main.gitSHA=$(GIT_SHA) -X main.version=$(VERSION) -X main.name=$(BINARY)'
-                   
+
 TAGS    = "netgo osusergo no_stage static_build"
 $(BINDIR)/$(BINARY): clean
 	$(GO) build -tags $(TAGS) -v $(LDFLAGS) -o $@

--- a/README.md
+++ b/README.md
@@ -20,12 +20,20 @@ remindme at 2:00 "go to the grocery store"
 remindme in 10m "join the call"
 ```
 
+To stop the server
+```sh
+$ kill -15 $(cat /tmp/remindme.pid)
+```
+
+The server startup is idempotent. If a new version is compiled or installed, just run `remindme -s &` again to start a new process
+with the latest binary version.
+
 ## Building
 
 There are 2 ways to build `remindme`.
 
 1. Run `make`.
-2. Run `docker build <CONTAINER_RePO_NAME>/remindme:v1.0.0 .`
+2. Run `docker build <CONTAINER_REPO_NAME>/remindme:v1.0.0 .`
 
 ## Contributions
 


### PR DESCRIPTION
Hi,

With this PR I'm adding idempotent capabilities to the server startup, avoiding multiple processes for the remindme server. Since their initialization execution do not save the process ID. If the binary is executed one more time, another process is spawned. 

Currently, to stop the server execution the process ID must be found using other tools, with this feature the PID is saved in a file and the server's process can be stopped using `cat` and `kill`.

If you think this feature add value to the current implementation would be awesome.

Please let me know if something need to be changed to this PR to be accepted. 

